### PR TITLE
Added graphql-engine in Utilities list

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ For Database Management
 * [sqitch](https://github.com/theory/sqitch) - Tool for managing versioned schema deployment
 * [pgmigrate](https://github.com/yandex/pgmigrate) - CLI tool to evolve schema migrations, developed by Yandex.
 * [pgcmp](https://github.com/cbbrowne/pgcmp) - Tool to compare database schemas, with capability to accept some persistent differences
+* [graphql-engine](https://github.com/hasura/graphql-engine) - Get Instant Realtime GraphQL APIs over PostgreSQL.
 
 ### Language bindings
 * Common Lisp: [Postmodern](https://github.com/marijnh/Postmodern)


### PR DESCRIPTION
Adds the [Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) which is a blazing-fast GraphQL server that gives you instant realtime GraphQL APIs over Postgres.